### PR TITLE
Disambiguate usage of Redirect

### DIFF
--- a/Sources/App/Modules/Redirect/Controllers/RedirectApiController.swift
+++ b/Sources/App/Modules/Redirect/Controllers/RedirectApiController.swift
@@ -9,10 +9,10 @@ import Vapor
 import Fluent
 import AppApi
 
-extension Redirect.Detail.Detail: Content { }
+extension AppApi.Redirect.Detail.Detail: Content { }
 
 struct RedirectApiController: ApiController {
-    typealias ApiModel = Redirect.Detail
+    typealias ApiModel = AppApi.Redirect.Detail
     typealias DatabaseModel = RedirectModel
     
     // MARK: - Validators
@@ -68,7 +68,7 @@ struct RedirectApiController: ApiController {
         return queryBuilder
     }
     
-    func listOutput(_ req: Request, _ models: Fluent.Page<RedirectModel>) async throws -> Fluent.Page<Redirect.Detail.List> {
+    func listOutput(_ req: Request, _ models: Fluent.Page<RedirectModel>) async throws -> Fluent.Page<AppApi.Redirect.Detail.List> {
         return try await models.concurrentMap { try await detailOutput(req, $0) }
     }
     
@@ -79,7 +79,7 @@ struct RedirectApiController: ApiController {
         return queryBuilder
     }
     
-    func detailOutput(_ req: Request, _ model: RedirectModel) async throws -> Redirect.Detail.Detail {
+    func detailOutput(_ req: Request, _ model: RedirectModel) async throws -> AppApi.Redirect.Detail.Detail {
         try .init(id: model.requireID(), source: model.source, destination: model.destination)
     }
     
@@ -89,7 +89,7 @@ struct RedirectApiController: ApiController {
         try await req.onlyFor(.admin)
     }
     
-    func createInput(_ req: Request, _ model: RedirectModel, _ input: Redirect.Detail.Create) async throws {
+    func createInput(_ req: Request, _ model: RedirectModel, _ input: AppApi.Redirect.Detail.Create) async throws {
         let source = try sanitize(input.source, ofType: .source)
         let destination = try sanitize(input.destination, ofType: .destination)
         guard source != destination else {
@@ -119,7 +119,7 @@ struct RedirectApiController: ApiController {
         try await req.onlyFor(.admin)
     }
     
-    func updateInput(_ req: Request, _ model: RedirectModel, _ input: Redirect.Detail.Update) async throws {
+    func updateInput(_ req: Request, _ model: RedirectModel, _ input: AppApi.Redirect.Detail.Update) async throws {
         try await createInput(req, model, input)
     }
     
@@ -130,7 +130,7 @@ struct RedirectApiController: ApiController {
     }
     
     
-    func patchInput(_ req: Request, _ model: RedirectModel, _ input: Redirect.Detail.Patch) async throws {
+    func patchInput(_ req: Request, _ model: RedirectModel, _ input: AppApi.Redirect.Detail.Patch) async throws {
         let updateContent = Redirect.Detail.Update(source: input.source ?? model.source, destination: input.destination ?? model.destination)
         return try await createInput(req, model, updateContent)
     }

--- a/Tests/AppTests/Redirect/RedirectApiCreateTests.swift
+++ b/Tests/AppTests/Redirect/RedirectApiCreateTests.swift
@@ -10,13 +10,13 @@ import XCTVapor
 import Fluent
 import Spec
 
-extension Redirect.Detail.Create: Content { }
+extension AppApi.Redirect.Detail.Create: Content { }
 
 final class RedirectApiCreateTests: AppTestCase, RedirectTest {
     private func getRedirectCreateContent(
         source: String = "this/is/source/\(UUID())",
         destination: String = "and/it/goes/to/\(UUID())"
-    ) async throws -> Redirect.Detail.Create {
+    ) async throws -> AppApi.Redirect.Detail.Create {
         .init(source: source, destination: destination)
     }
     

--- a/Tests/AppTests/Redirect/RedirectApiGetTests.swift
+++ b/Tests/AppTests/Redirect/RedirectApiGetTests.swift
@@ -30,7 +30,7 @@ final class RedirectApiGetTests: AppTestCase, RedirectTest {
             .bearerToken(adminToken)
             .expect(.ok)
             .expect(.json)
-            .expect(AppApi.Page<Redirect.Detail.List>.self) { content in
+            .expect(AppApi.Page<AppApi.Redirect.Detail.List>.self) { content in
                 XCTAssert(content.items.contains { $0.id == redirect1.id! })
                 XCTAssert(content.items.contains { $0.id == redirect2.id! })
             }

--- a/Tests/AppTests/Redirect/RedirectApiPatchTests.swift
+++ b/Tests/AppTests/Redirect/RedirectApiPatchTests.swift
@@ -10,7 +10,7 @@ import XCTVapor
 import Fluent
 import Spec
 
-extension Redirect.Detail.Patch: Content { }
+extension AppApi.Redirect.Detail.Patch: Content { }
 
 final class RedirectApiPatchTests: AppTestCase, RedirectTest {
     private func getRedirectPatchContent(
@@ -18,7 +18,7 @@ final class RedirectApiPatchTests: AppTestCase, RedirectTest {
         patchedSource: String? = nil,
         destination: String = "and/it/goes/to/\(UUID())",
         patchedDestination: String? = nil
-    ) async throws -> (redirect: RedirectModel, patchContent: Redirect.Detail.Patch) {
+    ) async throws -> (redirect: RedirectModel, patchContent: AppApi.Redirect.Detail.Patch) {
         let redirect = try await createNewRedirect(source: source, destination: destination)
         let patchContent = Redirect.Detail.Patch(source: patchedSource, destination: patchedDestination)
         return (redirect, patchContent)

--- a/Tests/AppTests/Redirect/RedirectApiUpdateTests.swift
+++ b/Tests/AppTests/Redirect/RedirectApiUpdateTests.swift
@@ -16,7 +16,7 @@ final class RedirectApiUpdateTests: AppTestCase, RedirectTest {
         updatedSource: String = "some/new/source/\(UUID())",
         destination: String = "and/it/goes/to/\(UUID())",
         updatedDestination: String = "a/different/destination/\(UUID())"
-    ) async throws -> (redirect: RedirectModel, updateContent: Redirect.Detail.Update) {
+    ) async throws -> (redirect: RedirectModel, updateContent: AppApi.Redirect.Detail.Update) {
         let redirect = try await createNewRedirect(source: source, destination: destination)
         let updateContent = Redirect.Detail.Update(source: updatedSource, destination: updatedDestination)
         return (redirect, updateContent)


### PR DESCRIPTION
Vapor now uses its own Redirect Type. Add `AppApi` in front of custom Redirect type to avoid problems